### PR TITLE
Add a custom face for dismissed notifications

### DIFF
--- a/ednc.el
+++ b/ednc.el
@@ -66,6 +66,14 @@
   '((t (:inherit default)))
   "Notification text.")
 
+(defface ednc-dismissed
+  '((t (:inherit default :strike-through t)))
+  "Default face for dismissed notifications.")
+
+(defcustom ednc-dismissed-face 'ednc-dismissed
+  "Face to be used for dismissed notifications."
+  :type 'face)
+
 ;;;###autoload
 (define-minor-mode ednc-mode
   "Act as a Desktop Notifications server and track notifications."
@@ -395,11 +403,11 @@ This function is destructive."
   "Remove OLD notification from its log buffer, if it exists."
   (cl-destructuring-bind (buffer . position)
       (alist-get 'logged (ednc-notification-amendments old) '(nil))
-    (when (buffer-live-p buffer)
+    (when (and (buffer-live-p buffer) ednc-dismissed-face)
       (with-current-buffer buffer
         (save-excursion
           (add-text-properties (goto-char position) (line-end-position)
-                               '(face (:strike-through t))))))))
+                               `(face ,ednc-dismissed-face)))))))
 
 (defun ednc--append-new-notification-to-log-buffer (new)
   "Append NEW notification to log buffer."

--- a/test.el
+++ b/test.el
@@ -231,7 +231,7 @@
         (should (string-equal " [test: foo]\nbar baz\n\n [test: foo]\ncorge\n\n"
                               (buffer-string)))
         (should (equal (get-text-property (point-min) 'face)
-                       '(:strike-through t)))))))
+                       ednc-dismissed-face))))))
 
 (ert-deftest ednc--log-replaced-notifications-test ()
   (ednc--with-temp-server


### PR DESCRIPTION
This allows users to disable the default strike-through, change colors, etc. For example:

```elisp
(set-face-attribute 'ednc-dismissed nil
                    :strike-through nil
                    :foreground "gray")
```

Or disable the face entirely:

```elisp
(setq ednc-dismissed-face nil)
```