### PR TITLE
Improve icon sizing

### DIFF
--- a/ednc.el
+++ b/ednc.el
@@ -312,10 +312,10 @@ This function modifies the notification's hints."
                 (ednc--path-to-image (ednc-notification-app-icon new))
                 (ednc--data-to-image (ednc--get-hint hints "icon_data" t)))))
       (when image
-        (setf (image-property image :max-height) (frame-char-height)
-              (image-property image :ascent) 90)
-        (push (cons 'icon (with-temp-buffer (insert-image image)
-                                            (buffer-string)))
+        (setf (image-property image :max-height) '(1.0 . ch)
+              (image-property image :scale) 1.0
+              (image-property image :ascent) 'center)
+        (push (cons 'icon (propertize " " 'display image))
                     (ednc-notification-amendments new))))))
 
 (defun ednc--get-hint (hints key &optional remove-flag)


### PR DESCRIPTION
Instead of using the frame's char height, set the icon's maximum height relative to the surrounding text. Additionally, center icons on the line (to avoid increasing the line height.